### PR TITLE
feat: interaction with the spotify api

### DIFF
--- a/src/spotify/api.py
+++ b/src/spotify/api.py
@@ -1,0 +1,22 @@
+from spotipy import Spotify, oauth2
+from typing import Union
+from . import track
+
+class SpotifyAPI(Spotify):
+    'Main class to interact with the Spotify Web API.'
+    def __init__(self, client_id: str, client_secret: str, redirect_uri: str = 'http://localhost:1024/redirect'):
+        Spotify.__init__(self, auth_manager = oauth2.SpotifyOAuth(
+            client_id = client_id,
+            client_secret = client_secret,
+            redirect_uri = redirect_uri,
+            scope = 'user-read-currently-playing',
+        ))
+    
+    def now_playing(self) -> Union[track.Track, None]:
+        result = self.current_user_playing_track()
+        return None if result is None else track.Track(result['item'])
+
+
+if __name__ == '__main__':
+    client = SpotifyAPI()
+    print(client.now_playing().title)

--- a/src/spotify/track.py
+++ b/src/spotify/track.py
@@ -1,0 +1,7 @@
+class Track(dict):
+    'Represents a now-playing track.'
+    def __init__(self, data: dict = None):
+        dict.__init__(self, data)
+        self.title = data['name']
+        self.artist = data['artists'][0]['name']
+        self.image = data['album']['images'][0]['url']


### PR DESCRIPTION
Example usage:
```
from spotify import api
client = api.SpotifyAPI(<CLIENT_ID>, <CLIENT_SECRET>)
track = client.now_playing()
print(track.title, track.artist, track.image)
```
<br/>

Steps to get the client_id and client_secret (users will have to follow this):
1. Log in to https://developer.spotify.com/dashboard
2. Create a new app
3. `Edit settings` > `Redirect URIs`, type `http://localhost:1024` and save
4. Copy the client_id and client_secret
5. Paste them in the yaml file?

The script may then pick them up from the yaml and pass them to the SpotifyAPI constructor.